### PR TITLE
Fix make error: pthread_mutex_lock was not declared in this scope

### DIFF
--- a/src/platform/linux/syst/dispatcher.cpp
+++ b/src/platform/linux/syst/dispatcher.cpp
@@ -18,6 +18,13 @@
 #include <unistd.h>
 #include "error_message.h"
 
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#define PTHREAD_MUTEX_INITIALIZER { { 0, 0, 0, 0, 0, { 0 } } }
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
 namespace syst
 {
 


### PR DESCRIPTION
I fixed an error that occurs on Linux:
```
make
  [ 56%] Building CXX object src/CMakeFiles/syst.dir/platform/linux/syst/dispatcher.cpp.o
  kryptokrona-1.1.2/src/platform/linux/syst/dispatcher.cpp: In constructor ‘syst::{anonymous}::MutextGuard::MutextGuard(pthread_mutex_t&)’:
  kryptokrona-1.1.2/src/platform/linux/syst/dispatcher.cpp:38:28: error: ‘pthread_mutex_lock’ was not declared in this scope; did you mean ‘pthread_mutex_t’?
   38 |                 auto ret = pthread_mutex_lock(&mutex);
      |                            ^~~~~~~~~~~~~~~~~~
      |                            pthread_mutex_t
```
The error I got is relating to POSIX function pthread_lock that compiler does not find.
It is necessary to add standard libs and some initialization. With my fix compiled fine.