### PR TITLE
Add concurrency to RPC

### DIFF
--- a/src/config/cryptonote_config.h
+++ b/src/config/cryptonote_config.h
@@ -311,9 +311,17 @@ namespace cryptonote
     const char P2P_STAT_TRUSTED_PUB_KEY[] = "";
 
     const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE = 256;
-    const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 10;
-    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = 100;
-    const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT = 2;
+    // Block cache. 10 MB is far too small for a multi-GB blockchain DB: it gives a
+    // near-zero cache-hit rate, so effectively every read hits disk. That makes RPC
+    // calls that touch the DB (e.g. getinfo's difficulty window) take seconds and lets
+    // any bulk-read client (p2pool header sync) starve the daemon. Busy nodes with more
+    // RAM should raise this further via --db-read-buffer-size (e.g. 2048).
+    const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 256;
+    // Max open SST files. 100 causes constant open/close thrashing on a DB with thousands
+    // of SST files. Keep below the process open-file (nofile) limit; raise via
+    // --db-max-open-files where the limit allows.
+    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = 512;
+    const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT = 4;
 
     const char LATEST_VERSION_URL[] = "https://github.com/kryptokrona/kryptokrona";
     const std::string LICENSE_URL = "https://github.com/kryptokrona/kryptokrona/blob/master/LICENSE";

--- a/src/cryptonote_core/core.cpp
+++ b/src/cryptonote_core/core.cpp
@@ -1087,6 +1087,11 @@ namespace cryptonote
     std::error_code Core::addBlock(const CachedBlock &cachedBlock, RawBlock &&rawBlock)
     {
         throwIfNotInitialized();
+        // Exclusive write lock. Adding a block mutates in-memory chain state (segments,
+        // indexes, caches) that concurrent RPC read handlers traverse under a shared lock,
+        // so block writes must be exclusive against them. This is the single funnel for all
+        // block additions (network blocks and submitBlock), so locking here covers writes.
+        std::unique_lock<std::shared_mutex> writeLock(m_accessLock);
         uint32_t blockIndex = cachedBlock.getBlockIndex();
         crypto::Hash blockHash = cachedBlock.getBlockHash();
         std::ostringstream os;
@@ -1664,6 +1669,10 @@ namespace cryptonote
 
     bool Core::addTransactionToPool(CachedTransaction &&cachedTransaction)
     {
+        // Exclusive write lock: mutating the pool (and validating against the chain) races
+        // with RPC read handlers that read the pool/chain under a shared lock. This is the
+        // funnel for both the BinaryArray overload and network transactions.
+        std::unique_lock<std::shared_mutex> writeLock(m_accessLock);
         TransactionValidatorState validatorState;
 
         auto transactionHash = cachedTransaction.getTransactionHash();
@@ -2013,6 +2022,16 @@ namespace cryptonote
 
     bool Core::getMinerData(MinerData &data) const
     {
+        // Full miner data = the cacheable block-derived part + the live mempool backlog.
+        if (!getMinerDataBlockPart(data))
+        {
+            return false;
+        }
+        return getMinerTxBacklog(data.txBacklog);
+    }
+
+    bool Core::getMinerDataBlockPart(MinerData &data) const
+    {
         throwIfNotInitialized();
 
         const uint32_t height = getTopBlockIndex() + 1;
@@ -2055,14 +2074,23 @@ namespace cryptonote
             data.medianTimestamp = common::medianValue(timestamps);
         }
 
-        // Mempool backlog so the pool can include fee-paying transactions.
-        data.txBacklog.clear();
+        return true;
+    }
+
+    bool Core::getMinerTxBacklog(std::vector<MinerDataTx> &backlog) const
+    {
+        throwIfNotInitialized();
+
+        // Mempool backlog so the pool can include fee-paying transactions. Rebuilt on
+        // every call: transactions can enter/leave the pool at any time, so this must
+        // never be served from a cache.
+        backlog.clear();
         for (const crypto::Hash &txHash : getPoolTransactionHashes())
         {
             try
             {
                 const TransactionDetails details = getTransactionDetails(txHash);
-                data.txBacklog.push_back(MinerDataTx{txHash, details.size, details.fee});
+                backlog.push_back(MinerDataTx{txHash, details.size, details.fee});
             }
             catch (const std::exception &)
             {

--- a/src/cryptonote_core/core.h
+++ b/src/cryptonote_core/core.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <ctime>
 #include <vector>
+#include <shared_mutex>
 #include <unordered_map>
 #include "blockchain_cache.h"
 #include "blockchain_messages.h"
@@ -155,6 +156,21 @@ namespace cryptonote
             std::vector<MinerDataTx> txBacklog;
         };
         bool getMinerData(MinerData &data) const;
+        // Block-derived portion of the miner data (everything except the mempool tx
+        // backlog). It is a pure function of the top block, so callers may memoize it
+        // keyed by the top-block hash (invalidate on a new block or reorg).
+        bool getMinerDataBlockPart(MinerData &data) const;
+        // Live mempool tx backlog. Changes whenever the pool changes (independently of
+        // blocks), so it must NOT be cached -- always rebuild it.
+        bool getMinerTxBacklog(std::vector<MinerDataTx> &backlog) const;
+
+        // Concurrency guard. Core was written for single-threaded (dispatcher) access;
+        // the RPC server now runs each request on a worker thread. Read handlers take a
+        // SHARED lock on this around their core access, and the block-add write path takes
+        // an EXCLUSIVE lock -- so reads run concurrently with each other but never while a
+        // block is being added. Held at request/write boundaries only (never nested in
+        // inner core methods) to avoid recursive-lock deadlocks.
+        std::shared_mutex &getAccessLock() const { return m_accessLock; }
 
     private:
         const Currency &currency;
@@ -173,6 +189,7 @@ namespace cryptonote
         IntrusiveLinkedList<MessageQueue<BlockchainMessage>> queueList;
         std::unique_ptr<IBlockchainCacheFactory> blockchainCacheFactory;
         std::unique_ptr<IMainChainStorage> mainChainStorage;
+        mutable std::shared_mutex m_accessLock;
         bool initialized;
 
         time_t start_time;

--- a/src/cryptonote_core/rocksdb_wrapper.cpp
+++ b/src/cryptonote_core/rocksdb_wrapper.cpp
@@ -9,6 +9,7 @@
 
 #include "rocksdb/cache.h"
 #include "rocksdb/table.h"
+#include "rocksdb/filter_policy.h"
 #include "rocksdb/db.h"
 #include "rocksdb/utilities/backupable_db.h"
 
@@ -223,6 +224,12 @@ rocksdb::Options RocksDBWrapper::getDBOptions(const DataBaseConfig &config)
     // level style compaction
     fOptions.compaction_style = rocksdb::kCompactionStyleLevel;
 
+    // Compression stays disabled because the vendored RocksDB is built WITHOUT compression
+    // libraries (external/rocksdb/CMakeLists.txt: WITH_LZ4 / WITH_ZSTD / WITH_SNAPPY = OFF),
+    // so selecting kLZ4/kZSTD/kSnappy here would fail at runtime. Enabling LZ4 on the upper
+    // levels + ZSTD on the bottommost would shrink the DB ~2-4x and cut disk I/O (a worthwhile
+    // follow-up), but requires turning those build options ON and adding the lz4/zstd deps to
+    // the CI matrix first.
     fOptions.compression_per_level.resize(fOptions.num_levels);
     for (int i = 0; i < fOptions.num_levels; ++i)
     {
@@ -231,6 +238,12 @@ rocksdb::Options RocksDBWrapper::getDBOptions(const DataBaseConfig &config)
 
     rocksdb::BlockBasedTableOptions tableOptions;
     tableOptions.block_cache = rocksdb::NewLRUCache(config.getReadCacheSize());
+    // A bloom filter (~10 bits/key) avoids a disk seek for point lookups that miss.
+    tableOptions.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
+    // Keep index and filter blocks in the block cache, and pin the L0 ones, so hot
+    // metadata stays in RAM instead of being re-read from disk on every lookup.
+    tableOptions.cache_index_and_filter_blocks = true;
+    tableOptions.pin_l0_filter_and_index_blocks_in_cache = true;
     std::shared_ptr<rocksdb::TableFactory> tfp(NewBlockBasedTableFactory(tableOptions));
     fOptions.table_factory = tfp;
 

--- a/src/rpc/http_server.cpp
+++ b/src/rpc/http_server.cpp
@@ -10,6 +10,7 @@
 
 #include <http/http_parser.h>
 #include <syst/interrupted_exception.h>
+#include <syst/remote_context.h>
 #include <syst/tcp_stream.h>
 #include <syst/ipv4_address.h>
 
@@ -81,7 +82,17 @@ namespace cryptonote
                 HttpResponse resp;
 
                 parser.receiveRequest(stream, req);
-                processRequest(req, resp);
+
+                // Run the (potentially blocking, DB-heavy) request handler on a worker
+                // thread instead of directly on the cooperative dispatcher. A RocksDB read
+                // is a blocking syscall that does not yield the dispatcher, so handling a
+                // request inline stalls every other connection until it finishes. Offloading
+                // lets the dispatcher keep serving other connections (and processing blocks)
+                // while this one's handler runs; the context yields until it completes.
+                // get() rethrows any handler exception here, preserving the catch below.
+                syst::RemoteContext<void> processingContext(m_dispatcher, [this, &req, &resp]
+                                                            { processRequest(req, resp); });
+                processingContext.get();
 
                 stream << resp;
                 stream.flush();

--- a/src/rpc/http_server.cpp
+++ b/src/rpc/http_server.cpp
@@ -83,16 +83,27 @@ namespace cryptonote
 
                 parser.receiveRequest(stream, req);
 
-                // Run the (potentially blocking, DB-heavy) request handler on a worker
-                // thread instead of directly on the cooperative dispatcher. A RocksDB read
-                // is a blocking syscall that does not yield the dispatcher, so handling a
-                // request inline stalls every other connection until it finishes. Offloading
-                // lets the dispatcher keep serving other connections (and processing blocks)
-                // while this one's handler runs; the context yields until it completes.
-                // get() rethrows any handler exception here, preserving the catch below.
-                syst::RemoteContext<void> processingContext(m_dispatcher, [this, &req, &resp]
-                                                            { processRequest(req, resp); });
-                processingContext.get();
+                if (offloadRequestProcessing())
+                {
+                    // Run the (potentially blocking, DB-heavy) request handler on a worker
+                    // thread instead of directly on the cooperative dispatcher. A RocksDB read
+                    // is a blocking syscall that does not yield the dispatcher, so handling a
+                    // request inline stalls every other connection until it finishes. Offloading
+                    // lets the dispatcher keep serving other connections (and processing blocks)
+                    // while this one's handler runs; the context yields until it completes.
+                    // get() rethrows any handler exception here, preserving the catch below.
+                    //
+                    // Only servers that opt in (see offloadRequestProcessing) take this path.
+                    // The wallet service's JsonRpcServer must NOT -- its handlers drive a
+                    // WalletService bound to this dispatcher and would crash off-thread.
+                    syst::RemoteContext<void> processingContext(m_dispatcher, [this, &req, &resp]
+                                                                { processRequest(req, resp); });
+                    processingContext.get();
+                }
+                else
+                {
+                    processRequest(req, resp);
+                }
 
                 stream << resp;
                 stream.flush();

--- a/src/rpc/http_server.h
+++ b/src/rpc/http_server.h
@@ -37,6 +37,18 @@ namespace cryptonote
     protected:
         syst::Dispatcher &m_dispatcher;
 
+        // Whether acceptLoop should run processRequest on a worker thread
+        // (syst::RemoteContext) instead of inline on the cooperative dispatcher.
+        // Off by default: the base behaviour is to process inline. Only servers
+        // whose handlers are self-contained (e.g. the daemon's Core/DB reads,
+        // whose cross-thread work is posted back via Dispatcher::remoteSpawn)
+        // may opt in. It MUST stay off for servers whose handlers drive
+        // dispatcher-bound state on this thread -- notably the wallet service's
+        // JsonRpcServer, which operates a WalletService/WalletGreen bound to
+        // this same dispatcher; running those off-dispatcher is undefined
+        // behaviour and crashes the process.
+        virtual bool offloadRequestProcessing() const { return false; }
+
     private:
         void acceptLoop();
         void connectionHandler(syst::TcpConnection &&conn);

--- a/src/rpc/rpc_server.cpp
+++ b/src/rpc/rpc_server.cpp
@@ -201,7 +201,20 @@ namespace cryptonote
             return;
         }
 
-        it->second.handler(this, request, response);
+        // Requests run on worker threads (see HttpServer::acceptLoop offload), so read
+        // handlers take a SHARED lock to run concurrently while staying safe against the
+        // exclusive block/pool write locks. Skip it for "/json_rpc" (locks per-method
+        // internally below) and "/sendrawtransaction" (write path locks internally) --
+        // shared-locking those would deadlock against the exclusive lock they take.
+        if (url == "/json_rpc" || url == "/sendrawtransaction")
+        {
+            it->second.handler(this, request, response);
+        }
+        else
+        {
+            std::shared_lock<std::shared_mutex> readLock(m_core.getAccessLock());
+            it->second.handler(this, request, response);
+        }
     }
 
     bool RpcServer::processJsonRpcRequest(const HttpRequest &request, HttpResponse &response)
@@ -252,7 +265,18 @@ namespace cryptonote
                 throw JsonRpcError(CORE_RPC_ERROR_CODE_CORE_BUSY, "Core is busy");
             }
 
-            it->second.handler(this, jsonRequest, jsonResponse);
+            // Read methods take a SHARED lock (concurrent). "submitblock" is a write and
+            // locks exclusively inside submitBlock/addBlock, so shared-locking it here would
+            // deadlock -- run it without the shared lock.
+            if (jsonRequest.getMethod() == "submitblock")
+            {
+                it->second.handler(this, jsonRequest, jsonResponse);
+            }
+            else
+            {
+                std::shared_lock<std::shared_mutex> readLock(m_core.getAccessLock());
+                it->second.handler(this, jsonRequest, jsonResponse);
+            }
         }
         catch (const JsonRpcError &err)
         {
@@ -1240,10 +1264,42 @@ namespace cryptonote
 
     bool RpcServer::on_get_miner_data(const COMMAND_RPC_GET_MINER_DATA::request & /*req*/, COMMAND_RPC_GET_MINER_DATA::response &res)
     {
+        // p2pool polls this every ~1-2s per connection, and the block-derived fields
+        // (difficulty/median windows etc.) cost ~3 x ~100-block DB reads to compute but
+        // only change when the top block changes. Memoize them keyed by the top-block
+        // hash so repeated polls between blocks are almost free. The mempool tx backlog
+        // is always rebuilt below so pool freshness is never sacrificed.
+        const crypto::Hash topHash = m_core.getTopBlockHash();
+
         Core::MinerData data;
-        if (!m_core.getMinerData(data))
+        bool cacheHit = false;
         {
-            throw json_rpc::JsonRpcError{CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: failed to gather miner data"};
+            std::lock_guard<std::mutex> lock(m_minerDataCacheMutex);
+            if (m_minerDataCacheValid && m_minerDataCacheTopHash == topHash)
+            {
+                data = m_minerDataCacheBlockPart;
+                cacheHit = true;
+            }
+        }
+
+        if (!cacheHit)
+        {
+            if (!m_core.getMinerDataBlockPart(data))
+            {
+                throw json_rpc::JsonRpcError{CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: failed to gather miner data"};
+            }
+            std::lock_guard<std::mutex> lock(m_minerDataCacheMutex);
+            // Key on the hash the block part was actually computed against (data.prevId),
+            // so a tip that moved mid-computation invalidates cleanly on the next call.
+            m_minerDataCacheBlockPart = data;
+            m_minerDataCacheTopHash = data.prevId;
+            m_minerDataCacheValid = true;
+        }
+
+        // Always rebuild the mempool backlog live -- never cached.
+        if (!m_core.getMinerTxBacklog(data.txBacklog))
+        {
+            throw json_rpc::JsonRpcError{CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: failed to gather miner tx backlog"};
         }
 
         res.major_version = data.majorVersion;
@@ -1362,7 +1418,7 @@ namespace cryptonote
 
     }
 
-    void RpcServer::fill_block_header_response(const BlockTemplate &blk, bool orphan_status, uint32_t index, const Hash &hash, block_header_response &response)
+    void RpcServer::fill_block_header_response(const BlockTemplate &blk, bool orphan_status, uint32_t index, const Hash &hash, block_header_response &response, bool lightweight)
     {
         response.major_version = blk.majorVersion;
         response.minor_version = blk.minorVersion;
@@ -1375,9 +1431,23 @@ namespace cryptonote
         response.hash = common::podToHex(hash);
         response.difficulty = m_core.getBlockDifficulty(index);
         response.reward = get_block_reward(blk);
-        BlockDetails blkDetails = m_core.getBlockDetails(hash);
-        response.num_txes = static_cast<uint32_t>(blkDetails.transactions.size());
-        response.block_size = blkDetails.blockSize;
+        if (lightweight)
+        {
+            // Bulk header queries (get_block_headers_range) must not call getBlockDetails:
+            // it restores the block template a SECOND time (we already have `blk`) and loads
+            // every transaction's details -- the dominant cost when serving 100s of headers.
+            // num_txes = non-coinbase tx hashes + the coinbase; block_size is approximated by
+            // the block template's serialized size (header + coinbase + tx hashes). These two
+            // fields are informational for header sync; the PoW/linkage fields above are exact.
+            response.num_txes = static_cast<uint32_t>(blk.transactionHashes.size() + 1);
+            response.block_size = getObjectBinarySize(blk);
+        }
+        else
+        {
+            BlockDetails blkDetails = m_core.getBlockDetails(hash);
+            response.num_txes = static_cast<uint32_t>(blkDetails.transactions.size());
+            response.block_size = blkDetails.blockSize;
+        }
     }
 
     bool RpcServer::on_get_last_block_header(const COMMAND_RPC_GET_LAST_BLOCK_HEADER::request &req, COMMAND_RPC_GET_LAST_BLOCK_HEADER::response &res)
@@ -1452,13 +1522,25 @@ namespace cryptonote
             return false;
         }
 
+        // Cap the range. Without this an unbounded request forces (end-start) full-block
+        // reads to be materialised in memory at once; many concurrent p2pool connections
+        // requesting large ranges is a memory/DB-load blowup that can OOM the daemon.
+        // Monero caps this endpoint the same way.
+        static const uint64_t MAX_BLOCK_HEADERS_RANGE = 1000;
+        if (req.end_height - req.start_height + 1 > MAX_BLOCK_HEADERS_RANGE)
+        {
+            error_resp.code = CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT;
+            error_resp.message = "Requested block header range is too large (max " + std::to_string(MAX_BLOCK_HEADERS_RANGE) + " blocks).";
+            return false;
+        }
+
         for (uint32_t h = static_cast<uint32_t>(req.start_height); h <= static_cast<uint32_t>(req.end_height); ++h)
         {
             crypto::Hash block_hash = m_core.getBlockHashByIndex(h);
             cryptonote::BlockTemplate blk = m_core.getBlockByHash(block_hash);
 
             res.headers.push_back(block_header_response());
-            fill_block_header_response(blk, false, h, block_hash, res.headers.back());
+            fill_block_header_response(blk, false, h, block_hash, res.headers.back(), /*lightweight=*/true);
 
             // TODO: Error handling like in monero?
             /*block blk;

--- a/src/rpc/rpc_server.h
+++ b/src/rpc/rpc_server.h
@@ -9,12 +9,16 @@
 #include "http_server.h"
 
 #include <functional>
+#include <mutex>
+#include <shared_mutex>
 #include <unordered_map>
 
 #include <logging/logger_ref.h>
 #include "common/math.h"
 #include "core_rpc_server_commands_definitions.h"
 #include "json_rpc.h"
+// Full definition needed: the get_miner_data cache holds a Core::MinerData by value.
+#include <cryptonote_core/core.h>
 
 namespace cryptonote
 {
@@ -98,7 +102,7 @@ namespace cryptonote
         bool on_get_block_header_by_hash(const COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH::request &req, COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH::response &res);
         bool on_get_block_header_by_height(const COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request &req, COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response &res);
 
-        void fill_block_header_response(const BlockTemplate &blk, bool orphan_status, uint32_t index, const crypto::Hash &hash, block_header_response &responce);
+        void fill_block_header_response(const BlockTemplate &blk, bool orphan_status, uint32_t index, const crypto::Hash &hash, block_header_response &responce, bool lightweight = false);
         RawBlockLegacy prepareRawBlockLegacy(BinaryArray &&blockBlob);
 
         bool f_on_blocks_list_json(const F_COMMAND_RPC_GET_BLOCKS_LIST::request &req, F_COMMAND_RPC_GET_BLOCKS_LIST::response &res);
@@ -114,6 +118,15 @@ namespace cryptonote
         std::vector<std::string> m_cors_domains;
         std::string m_fee_address;
         uint32_t m_fee_amount;
+
+        // get_miner_data cache. The block-derived fields are a pure function of the top
+        // block, so they are memoized here keyed by the top-block hash and invalidated on
+        // a new block or reorg. The mempool tx backlog is deliberately NOT cached -- it is
+        // rebuilt live on every request so newly arrived pool transactions are never stale.
+        std::mutex m_minerDataCacheMutex;
+        bool m_minerDataCacheValid = false;
+        crypto::Hash m_minerDataCacheTopHash{};
+        Core::MinerData m_minerDataCacheBlockPart;
     };
 
 }

--- a/src/rpc/rpc_server.h
+++ b/src/rpc/rpc_server.h
@@ -56,6 +56,10 @@ namespace cryptonote
         static std::unordered_map<std::string, RpcHandler<HandlerFunction>> s_handlers;
 
         virtual void processRequest(const HttpRequest &request, HttpResponse &response) override;
+        // The daemon's handlers are self-contained Core/DB reads (any cross-thread
+        // work is posted back via Dispatcher::remoteSpawn), so they are safe to run
+        // off the dispatcher and benefit from the concurrency. Opt in.
+        bool offloadRequestProcessing() const override { return true; }
         bool processJsonRpcRequest(const HttpRequest &request, HttpResponse &response);
         bool isCoreReady();
 


### PR DESCRIPTION
Add concurrency to make heavy RPC requests non-blocking to the core thread, as well as speeding up RPC calls in general.